### PR TITLE
fix compiler error "reference to 'system' is ambiguous"

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -899,7 +899,7 @@ bool AppInit2()
             LoadExternalBlockFile(file);
         }
 #if BOOST_VERSION >= 105000
-        system::error_code errcode;
+        boost::system::error_code errcode;
         filesystem::remove_all(pathOldblockchain, errcode);
         filesystem::copy_file(GetDataDir() / "wallet.dat", GetDataDir() / "wallet.dat.old", errcode);
 #else


### PR DESCRIPTION
init.cpp: In function 'bool AppInit2()':
init.cpp:902: error: reference to 'system' is ambiguous